### PR TITLE
update dependencies monthly as project goes into mothball

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,13 +9,13 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     commit-message:
       prefix: "[github-action] "
 
   - package-ecosystem: "nuget"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     commit-message:
       prefix: "[nuget] "


### PR DESCRIPTION
Reduce the frequency of dependabot updates. As this is a reusable component, maybe someone will want to use it, so not disabling entirely