### PR TITLE
pipeline: gitversioning with wildcard inside 6.1.0 range

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Install GitVersion
       uses: gittools/actions/gitversion/setup@v3.0.1
       with:
-        versionSpec: '6.x'
+        versionSpec: '6.0.x'
 
     - name: Determine generated version number
       id: version_step # step id used as reference for output values


### PR DESCRIPTION
Main has a failing version issue, and exists for newer versions of this step too see #39 build.