### PR TITLE
feat: Remove Task.Result blocking in `SearchClient.SearchAsync`

### DIFF
--- a/Dfe.Data.Common.Infrastructure.CognitiveSearch/SearchByKeyword/DefaultSearchByKeywordService.cs
+++ b/Dfe.Data.Common.Infrastructure.CognitiveSearch/SearchByKeyword/DefaultSearchByKeywordService.cs
@@ -86,7 +86,7 @@ public sealed class DefaultSearchByKeywordService : ISearchByKeywordService
         return InvokeSearch(
             searchIndex, async (searchClient) =>
                 await searchClient.SearchAsync<TSearchResult>(
-                    searchKeyword, searchOptions));
+                    searchKeyword, searchOptions).ConfigureAwait(false));
     }
 
     /// <summary>
@@ -113,6 +113,6 @@ public sealed class DefaultSearchByKeywordService : ISearchByKeywordService
 
         SearchClient client = await _searchClientProvider.InvokeSearchClientAsync(searchIndex);
 
-        return await searchAction(client);
+        return await searchAction(client).ConfigureAwait(false);
     }
 }


### PR DESCRIPTION
Remove `searchClientProvider.GetClient().Result` in favour of async await.
Remove `searchClient.InvokeClientAsync(t => ).Result` in favour of an awaited async delegate