### PR TITLE
feat: Retrieve IndexNames from configuration

### DIFF
--- a/Dfe.Data.Common.Infrastructure.CognitiveSearch/SearchByKeyword/IndexNames/Options/SearchIndexNamesOptions.cs
+++ b/Dfe.Data.Common.Infrastructure.CognitiveSearch/SearchByKeyword/IndexNames/Options/SearchIndexNamesOptions.cs
@@ -1,0 +1,11 @@
+﻿namespace Dfe.Data.Common.Infrastructure.CognitiveSearch.SearchByKeyword.IndexNames.Options;
+/// <summary>
+/// 
+/// </summary>
+public sealed class SearchIndexNamesOptions
+{
+    /// <summary>
+    /// Rules for Azure Search index names https://learn.microsoft.com/en-us/rest/api/searchservice/naming-rules 
+    /// </summary>
+    public List<string>? Names { get; set; }
+}

--- a/Dfe.Data.Common.Infrastructure.CognitiveSearch/SearchByKeyword/IndexNames/Providers/AzureConfigurationSearchIndexNamesProvider.cs
+++ b/Dfe.Data.Common.Infrastructure.CognitiveSearch/SearchByKeyword/IndexNames/Providers/AzureConfigurationSearchIndexNamesProvider.cs
@@ -1,0 +1,33 @@
+﻿using Dfe.Data.Common.Infrastructure.CognitiveSearch.SearchByKeyword.IndexNames.Options;
+
+namespace Dfe.Data.Common.Infrastructure.CognitiveSearch.SearchByKeyword.IndexNames.Providers;
+/// <summary>
+/// 
+/// </summary>
+public sealed class AzureConfigurationSearchIndexNamesProvider : ISearchIndexNamesProvider
+{
+    private readonly IReadOnlyList<string> _indexNames;
+
+    /// <summary>
+    /// 
+    /// </summary>
+    /// <param name="searchIndexNamesOptions"></param>
+    /// <exception cref="ArgumentException"></exception>
+    public AzureConfigurationSearchIndexNamesProvider(SearchIndexNamesOptions searchIndexNamesOptions)
+    {
+        ArgumentNullException.ThrowIfNull(searchIndexNamesOptions);
+
+        if (searchIndexNamesOptions.Names is null || searchIndexNamesOptions.Names.Count == 0)
+        {
+            throw new ArgumentException("IndexNames cannot be null or empty");
+        }
+
+        _indexNames = searchIndexNamesOptions.Names;
+    }
+
+    /// <summary>
+    /// 
+    /// </summary>
+    /// <returns></returns>
+    public IEnumerable<string> GetIndexNames() => _indexNames;
+}

--- a/Dfe.Data.Common.Infrastructure.CognitiveSearch/SearchByKeyword/IndexNames/Providers/AzureRemoteSearchIndexNamesProvider.cs
+++ b/Dfe.Data.Common.Infrastructure.CognitiveSearch/SearchByKeyword/IndexNames/Providers/AzureRemoteSearchIndexNamesProvider.cs
@@ -3,14 +3,14 @@ using Azure.Search.Documents.Indexes;
 using Dfe.Data.Common.Infrastructure.CognitiveSearch.SearchByKeyword.Options;
 using Microsoft.Extensions.Options;
 
-namespace Dfe.Data.Common.Infrastructure.CognitiveSearch.SearchByKeyword.Providers;
+namespace Dfe.Data.Common.Infrastructure.CognitiveSearch.SearchByKeyword.IndexNames.Providers;
 
 /// <summary>
 /// Provides the means by which to derive all the configured
 /// indexes under which to search, established under configuration.
 /// accessible by index name.
 /// </summary>
-public sealed class SearchIndexNamesProvider : ISearchIndexNamesProvider
+public sealed class AzureRemoteSearchIndexNamesProvider : ISearchIndexNamesProvider
 {
     private readonly AzureSearchConnectionOptions _azureSearchOptions;
 
@@ -23,7 +23,7 @@ public sealed class SearchIndexNamesProvider : ISearchIndexNamesProvider
     /// Configuration options used to define the internal Azure
     /// cognitive search service credentials and Uri endpoint.
     /// </param>
-    public SearchIndexNamesProvider(IOptions<AzureSearchConnectionOptions> azureSearchOptions)
+    public AzureRemoteSearchIndexNamesProvider(IOptions<AzureSearchConnectionOptions> azureSearchOptions)
     {
         ArgumentNullException.ThrowIfNull(azureSearchOptions);
 

--- a/Dfe.Data.Common.Infrastructure.CognitiveSearch/SearchByKeyword/IndexNames/Providers/ISearchIndexNamesProvider.cs
+++ b/Dfe.Data.Common.Infrastructure.CognitiveSearch/SearchByKeyword/IndexNames/Providers/ISearchIndexNamesProvider.cs
@@ -1,4 +1,4 @@
-﻿namespace Dfe.Data.Common.Infrastructure.CognitiveSearch.SearchByKeyword.Providers;
+﻿namespace Dfe.Data.Common.Infrastructure.CognitiveSearch.SearchByKeyword.IndexNames.Providers;
 
 /// <summary>
 /// Provides the contract by which to derive all the configured

--- a/Dfe.Data.Common.Infrastructure.CognitiveSearch/SearchByKeyword/Providers/SearchByKeywordClientProvider.cs
+++ b/Dfe.Data.Common.Infrastructure.CognitiveSearch/SearchByKeyword/Providers/SearchByKeywordClientProvider.cs
@@ -1,5 +1,6 @@
 ﻿using Azure;
 using Azure.Search.Documents;
+using Dfe.Data.Common.Infrastructure.CognitiveSearch.SearchByKeyword.IndexNames.Providers;
 using Microsoft.Extensions.Options;
 
 namespace Dfe.Data.Common.Infrastructure.CognitiveSearch.SearchByKeyword.Providers;

--- a/Dfe.Data.Common.Infrastructure.CognitiveSearch/Tests/SearchByKeyword/IndexNames/AzureConfigurationSearchIndexNamesProviderTests.cs
+++ b/Dfe.Data.Common.Infrastructure.CognitiveSearch/Tests/SearchByKeyword/IndexNames/AzureConfigurationSearchIndexNamesProviderTests.cs
@@ -1,0 +1,65 @@
+﻿using Dfe.Data.Common.Infrastructure.CognitiveSearch.SearchByKeyword.IndexNames.Options;
+using Dfe.Data.Common.Infrastructure.CognitiveSearch.SearchByKeyword.IndexNames.Providers;
+using Xunit;
+
+namespace Dfe.Data.Common.Infrastructure.CognitiveSearch.Tests.SearchByKeyword.IndexNames;
+public sealed class AzureConfigurationSearchIndexNamesProviderTests
+{
+    [Fact]
+    public void Constructor_Throws_When_OptionsIsNull()
+    {
+        // Arrange
+        SearchIndexNamesOptions? options = null;
+
+        // Act & Assert
+        Assert.Throws<ArgumentNullException>(() => new AzureConfigurationSearchIndexNamesProvider(options!));
+    }
+
+    [Fact]
+    public void Constructor_Throws_When_Options_Names_Is_Null()
+    {
+        // Arrange
+        SearchIndexNamesOptions? options = new()
+        {
+            Names = null
+        };
+
+        // Act & Assert
+        Assert.Throws<ArgumentException>(() => new AzureConfigurationSearchIndexNamesProvider(options!));
+    }
+
+    [Fact]
+    public void Constructor_Throws_When_Options_Names_Has_NoValues()
+    {
+        // Arrange
+        SearchIndexNamesOptions? options = new()
+        {
+            Names = []
+        };
+
+        // Act & Assert
+        Assert.Throws<ArgumentException>(() => new AzureConfigurationSearchIndexNamesProvider(options!));
+    }
+
+    [Fact]
+    public void GetIndexNames_ReturnsExpectedIndexNames()
+    {
+        // Arrange
+        List<string> expectedIndexNames = ["index-1", "INDEX-2", " Index-3 "];
+
+        SearchIndexNamesOptions options = new()
+        {
+            Names = expectedIndexNames
+        };
+
+        AzureConfigurationSearchIndexNamesProvider provider = new(options);
+
+        // Act
+        IEnumerable<string> actualIndexNames = provider.GetIndexNames();
+
+        // Assert
+        Assert.NotNull(actualIndexNames);
+        Assert.Equal(expectedIndexNames.Count, actualIndexNames.Count());
+        Assert.All(expectedIndexNames, indexName => Assert.Contains(indexName, actualIndexNames));
+    }
+}

--- a/Dfe.Data.Common.Infrastructure.CognitiveSearch/Tests/SearchByKeyword/Providers/SearchByKeywordClientProviderTests.cs
+++ b/Dfe.Data.Common.Infrastructure.CognitiveSearch/Tests/SearchByKeyword/Providers/SearchByKeywordClientProviderTests.cs
@@ -1,4 +1,5 @@
-﻿using Dfe.Data.Common.Infrastructure.CognitiveSearch.SearchByKeyword.Providers;
+﻿using Dfe.Data.Common.Infrastructure.CognitiveSearch.SearchByKeyword.IndexNames.Providers;
+using Dfe.Data.Common.Infrastructure.CognitiveSearch.SearchByKeyword.Providers;
 using Dfe.Data.Common.Infrastructure.CognitiveSearch.Tests.Search.TestDoubles;
 using Dfe.Data.Common.Infrastructure.CognitiveSearch.Tests.SearchByKeyword.TestDoubles.StubBuilders;
 using FluentAssertions;


### PR DESCRIPTION
The current implementation of `ISearchIndexNamesProvider` requires an Admin Key as GET `/indexes` is an administrative operation. This opens a security issue with a consumer requiring elevated credentials to provide valid index names.

As `SearchByKeywordClientProvider` eagerly evaluates `GetIndexNames` when constructed - and it has a Singleton lifetime ... when Singletons are created as the container lifetime progresses, it'll immediately evaluate GetIndexNames on startup.

This change

1) allows consumers to use `Query` keys and not require an `Admin` key - by `ISearchIndexNamesProvider` providing through configuration.

2) Creates a non-breaking extension that removes existing `ISearchIndexNames` provider and registers the Configuration based retrieval of IndexNames, which consumers will need to call.

3) The eager-consumption does not need to be adjusted - because Options are retrieved than a call to `SearchClient.GetIndexNames()` with 2)


---

In future;

Consider passing configuration wrapper around `AddAzureSearchServices`; single composition but allows configuration, than having to call 2 Composition extensions,

```cs
public static IServiceCollection AddAzureSearchServices(this IServiceCollection services, IConfiguration configuration, Action<AzureSearchServiceRegistrationOptions> configure)
{
  services.Add....
  AzureSearchServiceRegistrationOptions opts = new();
  configure(opts);
  
  options.IndexNamesMode == Remote ? AddSingleton<Remote> : AddSingleton<Configuration>()...
}
```
